### PR TITLE
Fix code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/NodeJS/controllers/authController.js
+++ b/NodeJS/controllers/authController.js
@@ -39,7 +39,7 @@ exports.signup = async (req, res) => {
 exports.login = async (req, res) => {
   const { email, password } = req.body;
   try {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     if (!user || !(await user.matchPassword(password))) {
       return sendError(res, 401, 'INVALID_CREDENTIALS', 'Invalid email or password');
     }


### PR DESCRIPTION
Fixes [https://github.com/sandipdevelopers/MEAN-stack-prectical-interview/security/code-scanning/3](https://github.com/sandipdevelopers/MEAN-stack-prectical-interview/security/code-scanning/3)

To fix the problem, we need to ensure that the user input is sanitized or validated before being used in the database query. For MongoDB, using the `$eq` operator can help ensure that the input is treated as a literal value. Alternatively, we can validate the input to ensure it is a string.

The best way to fix this without changing existing functionality is to use the `$eq` operator in the query. This change will be made in the `login` function in the `NodeJS/controllers/authController.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
