### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/NodeJS/routes/authRoutes.js
+++ b/NodeJS/routes/authRoutes.js
@@ -14,7 +14,14 @@ const loginLimiter = rateLimit({
 
 router.post('/signup', signup);
 router.post('/login', loginLimiter, login);
-router.get('/protected', protect, (req, res) => {
+// Rate limiter: maximum of 10 requests per minute for protected routes
+const protectedLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // limit each IP to 10 requests per windowMs
+  message: 'Too many requests from this IP, please try again after a minute'
+});
+
+router.get('/protected', protectedLimiter, protect, (req, res) => {
   res.send('This is a protected route');
 });
 


### PR DESCRIPTION
Fixes [https://github.com/sandipdevelopers/MEAN-stack-prectical-interview/security/code-scanning/2](https://github.com/sandipdevelopers/MEAN-stack-prectical-interview/security/code-scanning/2)

To fix the problem, we will add a rate limiter to the `/protected` route. This will involve creating a new rate limiter instance and applying it to the route in the same way it is applied to the `/login` route. We will use the `express-rate-limit` package, which is already imported in the file.

1. Define a new rate limiter for the `/protected` route.
2. Apply this rate limiter to the `/protected` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
